### PR TITLE
Change default icon's name

### DIFF
--- a/_docs-v5/toolbar/buttonIcons.md
+++ b/_docs-v5/toolbar/buttonIcons.md
@@ -9,10 +9,10 @@ Object, *default:*
 
 ```js
 {
-  prev: 'left-single-arrow',
-  next: 'right-single-arrow',
-  prevYear: 'left-double-arrow',
-  nextYear: 'right-double-arrow'
+  prev: 'chevron-left',
+  next: 'chevron-right',
+  prevYear: 'chevron-double-left',
+  nextYear: 'chevron-double-right'
 }
 ```
 </div>

--- a/_docs-v5/toolbar/buttonIcons.md
+++ b/_docs-v5/toolbar/buttonIcons.md
@@ -11,8 +11,8 @@ Object, *default:*
 {
   prev: 'chevron-left',
   next: 'chevron-right',
-  prevYear: 'chevron-double-left',
-  nextYear: 'chevron-double-right'
+  prevYear: 'chevrons-left',
+  nextYear: 'chevrons-right'
 }
 ```
 </div>


### PR DESCRIPTION
I've been trying to put the default icons in customButtons like documentation says, but no success (Angular 9). I noticed a change of icon's name. At least this work for v5.