### PR TITLE
return "mom.format()" is not clear

### DIFF
--- a/_docs-v4/date-display/columnHeaderText.md
+++ b/_docs-v4/date-display/columnHeaderText.md
@@ -18,7 +18,7 @@ var calendar = new Calendar(calendarEl, {
     if (date.getDay() === 5) {
       return 'Friday!';
     } else {
-      return mom.format('LLL');
+      return moment(date).format('LLL');
     }
   }
 });


### PR DESCRIPTION
Change return type to indicate you must pass date to moment() in order to format.