### PR TITLE
Update updateSize doc to clarify location

### DIFF
--- a/_docs-v5/sizing/updateSize.md
+++ b/_docs-v5/sizing/updateSize.md
@@ -6,7 +6,7 @@ type: method
 Immediately forces the calendar to readjusts its size.
 
 <div class='spec' markdown='1'>
-.updateSize()
+calendar.updateSize()
 </div>
 
 This is useful in a scenario where the calendar lives inside of an element, and that element's width has been dynamically changed. Call `updateSize` to help the calendar compensate. This method is also useful if you have [handleWindowResize](handleWindowResize) turned off.


### PR DESCRIPTION
It was pretty challenging to figure out where the method was located when the docs just say `.updateSize()`, especially if you are using the React library. It is already a little tricky to figure out how to access the Calendar API.