### PR TITLE
Change 'specify' to 'specifying' - minor grammar edit

### DIFF
--- a/_docs-v5/resource-data/resource-parsing.md
+++ b/_docs-v5/resource-data/resource-parsing.md
@@ -141,7 +141,7 @@ resources: [
 
 ## Nested resources with a flat array
 
-An alternative method for specify child resources is via linking them together with the `parentId` property. This is often more pleasant when dealing with resource data that originates from a database.
+An alternative method for specifying child resources is via linking them together with the `parentId` property. This is often more pleasant when dealing with resource data that originates from a database.
 
 ```js
 resources: [


### PR DESCRIPTION
Change:
An alternative method for specify

To:
An alternative method for specifying