### PR TITLE
Fix fullcalendar moment-timezone script src

### DIFF
--- a/_docs-v5/date-library/moment-timezone-plugin.md
+++ b/_docs-v5/date-library/moment-timezone-plugin.md
@@ -49,7 +49,7 @@ You can also configure the moment-timezone plugin with [script tags](initialize-
 <script src='https://cdn.jsdelivr.net/npm/fullcalendar@5.10.1/main.min.js'></script>
 
 <!-- the connector. must go AFTER moment-timezone -->
-<script src='https://cdn.jsdelivr.net/npm/@fullcalendar/moment@5.5.0/main.global.min.js'></script>
+<script src='https://cdn.jsdelivr.net/npm/@fullcalendar/moment-timezone@5.10.1/main.global.min.js'></script>
 
 <script>
   var calendarEl = document.getElementById('calendar')


### PR DESCRIPTION
This page is for the moment timezone plugin but was referencing the fullcalendar moment plugin (same url as the moment plugin doc page). 