### PR TITLE
[Docs] Button "edit doc" link is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See a problem with the docs? Create a ticket in the [main dev repo's issue track
 
 ## Contributing
 
-To make edits to the documentation please submit a [Pull Request](https://help.github.com/articles/creating-a-pull-request/) against the `master` branch of this repo.
+To make edits to the documentation please submit a [Pull Request](https://help.github.com/articles/creating-a-pull-request/) against the `main` branch of this repo.
 
 
 ## Getting Set Up

--- a/_includes/docs-controls/edit-button.html
+++ b/_includes/docs-controls/edit-button.html
@@ -1,6 +1,6 @@
 
 <a class='control-button'
-  href='https://github.com/fullcalendar/fullcalendar-site-static/edit/master/{{ page.path | escape }}'
+  href='https://github.com/fullcalendar/fullcalendar-site-static/edit/main/{{ page.path | escape }}'
   target='_blank'
   >
   <span class='control-button__text'>


### PR DESCRIPTION
Hi,

Fixes [#6807](https://github.com/fullcalendar/fullcalendar/issues/6807)

For this PR, I:

- Fix broken link for edit button, by replacing the main branch by `main`, because it seems that the main branch of your documentation has changed.
- I also took the opportunity to change the name of the main contribution branch in the README