### PR TITLE
fix headerToolbar properties

### DIFF
--- a/_docs-v5/toolbar/headerToolbar.md
+++ b/_docs-v5/toolbar/headerToolbar.md
@@ -9,9 +9,9 @@ Object/`false`, *default:*
 
 ```js
 {
-  start: 'title', // will normally be on the left. if RTL, will be on the right
+  left: 'title', // will normally be on the left. if RTL, will be on the right
   center: '',
-  end: 'today prev,next' // will normally be on the right. if RTL, will be on the left
+  right: 'today prev,next' // will normally be on the right. if RTL, will be on the left
 }
 ```
 </div>


### PR DESCRIPTION
The `start` and `end` properties did not work for me, but `left` and `right` do. 
`left` and `right` is also what is in the codepen demo referenced in the docs [here](https://codepen.io/pen?&editors=001)