### PR TITLE
Adds closing brackets to fix broken markdown contents

### DIFF
--- a/_docs-v5/timegrid-view/eventShortHeight.md
+++ b/_docs-v5/timegrid-view/eventShortHeight.md
@@ -16,8 +16,7 @@ Example of a regular event:
   alt='Screenshot of event with regular height'
   class='bordered-image'
   width='179'
-  height='104'
->
+  height='104'>
 
 Example of a "short" event:
 
@@ -26,5 +25,4 @@ Example of a "short" event:
   alt='Screenshot of event with short height'
   class='bordered-image'
   width='179'
-  height='104'
->
+  height='104'>

--- a/_docs-v6/timegrid-view/eventShortHeight.md
+++ b/_docs-v6/timegrid-view/eventShortHeight.md
@@ -16,8 +16,7 @@ Example of a regular event:
   alt='Screenshot of event with regular height'
   class='bordered-image'
   width='179'
-  height='104'
->
+  height='104'>
 
 Example of a "short" event:
 
@@ -26,5 +25,4 @@ Example of a "short" event:
   alt='Screenshot of event with short height'
   class='bordered-image'
   width='179'
-  height='104'
->
+  height='104'>


### PR DESCRIPTION
Currently, the document does not have `img` rendered. This PR fixes the problem.