### PR TITLE
typo: unescapted -> unescaped

### DIFF
--- a/_docs-v5/intro/content-injection.md
+++ b/_docs-v5/intro/content-injection.md
@@ -5,7 +5,7 @@ title: Content Injection
 Custom content can be injected into FullCalendar's DOM in various places. This content can be provided in the following formats. These examples use `eventContent` from the [event render hooks](event-render-hooks):
 
 
-**unescapted text**, provided as a string:
+**unescaped text**, provided as a string:
 
 ```js
 eventContent: 'some text'

--- a/_docs-v6/intro/content-injection.md
+++ b/_docs-v6/intro/content-injection.md
@@ -5,7 +5,7 @@ title: Content Injection
 Custom content can be injected into FullCalendar's DOM in various places. This content can be provided in the following formats. These examples use `eventContent` from the [event render hooks](event-render-hooks):
 
 
-**unescapted text**, provided as a string:
+**unescaped text**, provided as a string:
 
 ```js
 eventContent: 'some text'


### PR DESCRIPTION
The content injection page does not seem to be in the same place in the v4 docs? If it's moved I didn't find it, if it's new in v5 then no earlier pages would need updating.