### PR TITLE
Include `didMount` and `willUnmount` in documented example.

### DIFF
--- a/_docs-v6/custom-views/custom-view-with-js.md
+++ b/_docs-v6/custom-views/custom-view-with-js.md
@@ -8,7 +8,7 @@ For advanced developers, FullCalendar provides an API for building custom views 
 
 ## Config Object
 
-You can define an "config object" with functions that execute rendering. Example:
+You can define a view's "config object" with functions that execute rendering. Example:
 
 ```js
 import { sliceEvents, createPlugin } from '@fullcalendar/core';
@@ -28,6 +28,14 @@ const CustomViewConfig = {
       '</div>'
 
     return { html: html }
+  },
+
+  didMount: function(props) {
+    console.log('custom view now loaded');
+  },
+
+  willUnmount: function(props) {
+    console.log('view is about to change away from custom view');
   }
 
 }


### PR DESCRIPTION
Descriptions of the custom views with JavaScript should at least include a simple reference to the `didMount` and `willUnmount` methods that are invoked when the custom view has just loaded or is about to be unloaded, respectively. I had to go digging in the test cases to find that these event existed and they seem a common use case.