### PR TITLE
Adding view and el properties to All-Day Render Hooks

### DIFF
--- a/_docs-v6/timegrid-view/all-day-render-hooks.md
+++ b/_docs-v6/timegrid-view/all-day-render-hooks.md
@@ -19,3 +19,5 @@ Customize parts of the UI that typically display the text "all-day".
 When the above hooks are specified as a function in the form `function(arg)`, the `arg` is an object with the following properties:
 
 - `text`
+- `view`
+- `el` - the `<td>` element. only available in `allDayDidMount` and `allDayWillUnmount`


### PR DESCRIPTION
Just came across this while trying to do some custom styling using the timeGridWeek view and copied the same description format for the 'el' property from the Day-Cell Render Hooks page.