### PR TITLE
Prefer arrow function over .bind(this)

### DIFF
--- a/_docs-v6/third-party/angular.md
+++ b/_docs-v6/third-party/angular.md
@@ -88,7 +88,7 @@ import { CalendarOptions } from '@fullcalendar/core';
 export class AppComponent {
   calendarOptions: CalendarOptions = {
     initialView: 'dayGridMonth',
-    dateClick: this.handleDateClick.bind(this), // MUST ensure `this` context is maintained
+    dateClick: (arg) => this.handleDateClick(arg),
     events: [
       { title: 'event 1', date: '2019-04-01' },
       { title: 'event 2', date: '2019-04-02' }
@@ -124,7 +124,7 @@ import { CalendarOptions, EventsInput } from '@fullcalendar/core';
 export class AppComponent {
   calendarOptions: CalendarOptions = {
     initialView: 'dayGridMonth',
-    dateClick: this.handleDateClick.bind(this)
+    dateClick: (arg) => this.handleDateClick(arg)
   };
   eventsPromise: Promise<EventsInput>;
 


### PR DESCRIPTION
In my personal opinion, it's better to use an arrow function as a call-back then directly passing in a function and using .bind(this) to keep the scope. Arrow functions are now widely known and provide more flexibility, plus arrow functions do not have a scope.

When the function is called by the arrow function, the other function will still remain in the correct scope as well, so no need for custom binding

That being said, I can't find dateClick inside the CalendarOptions object, it would be nice to type hint args as well