### PR TITLE
Initialize with ES6: Add calendar.render()

### DIFF
--- a/_docs-v6/intro/initialize-es6.md
+++ b/_docs-v6/intro/initialize-es6.md
@@ -42,6 +42,7 @@ let calendar = new Calendar(calendarEl, {
     right: 'dayGridMonth,timeGridWeek,listWeek'
   }
 });
+calendar.render();
 ...
 ```
 
@@ -70,6 +71,7 @@ let calendar = new Calendar(calendarEl, {
     // your resource list
   ]
 });
+calendar.render();
 ...
 ```
 


### PR DESCRIPTION
I was reading the "Initialize with ES6 Build System" document and expecting to end up with a working example. But I ended up with a blank page. I had to look into other documents to figure out that I need to call render() after creating the Calendar object.