### PR TITLE
fix the example link for vuex inside vue.md

### DIFF
--- a/_docs-v6/third-party/vue.md
+++ b/_docs-v6/third-party/vue.md
@@ -238,7 +238,7 @@ For `@fullcalendar/vue` (Vue 2), it is recommended to use [class-based component
 
 ## Vuex
 
-[Vuex](https://vuex.vuejs.org/) is a popular state management library for Vue that works well with the FullCalendar connector. <a href='https://github.com/fullcalendar/fullcalendar-examples/tree/main/vue-vuex' class='more-link'>View an example project</a>
+[Vuex](https://vuex.vuejs.org/) is a popular state management library for Vue that works well with the FullCalendar connector. <a href='https://github.com/fullcalendar/fullcalendar-examples/tree/main/vue2-vuex' class='more-link'>View an example project</a>
 
 
 ## Nuxt


### PR DESCRIPTION
Looks like the Vuex example link was not updated