### PR TITLE
Note that the day header hook receives a Date generated in UTC.

### DIFF
--- a/_docs-v6/date-display/day-header-render-hooks.md
+++ b/_docs-v6/date-display/day-header-render-hooks.md
@@ -7,7 +7,7 @@ Customize the header elements above the day cells in daygrid and timegrid views 
 
 `dayHeaderClassNames` - a [ClassName Input](classname-input) for adding classNames to the header `<th>` cell
 
-`dayHeaderContent` - a [Content Injection Input](content-injection). Generated content is inserted *inside* the inner-most wrapper of the header cell. It does not replace the `<th>` cell.
+`dayHeaderContent` - a [Content Injection Input](content-injection). Generated content is inserted *inside* the inner-most wrapper of the header cell. It does not replace the `<th>` cell. Note that the date provided to the hook was generated in UTC.
 
 `dayHeaderDidMount` - called right after the `<th>` has been added to the DOM
 


### PR DESCRIPTION
I used the `Intl` facility to render day headers in users' locales. This renders dates in the user's time zone, whereas the provided `Date` was created in UTC. This caused a surprise for users "west" of UTC, where the day header rendered a day previous. People living in +13:00 would have seen the day after!

Happy to make any adjustments to the changes or the commit message!