### PR TITLE
Update event-parsing.md; Mention conversion of number into string

### DIFF
--- a/_docs-v6/event-model/event-parsing.md
+++ b/_docs-v6/event-model/event-parsing.md
@@ -26,6 +26,7 @@ Here are all the available properties, **all of which are optional**:
   <th>id</th>
   <td markdown='1'>
   String or Integer. Will uniquely identify your event. Useful for [getEventById](Calendar-getEventById).
+  It will be converted to a string.
   </td>
   </tr>
 


### PR DESCRIPTION
I have an internal mapping of events. I thought `===` works because `String or Integer` is mentioned (thinking that FullCalendar uses generics to not change the type).
Apparently, it will be converted into a string.