### PR TITLE
Note requirement of "@fullcalendar/premium-common"

### DIFF
--- a/_docs-v6/intro/initialize-globals.md
+++ b/_docs-v6/intro/initialize-globals.md
@@ -135,3 +135,5 @@ You can also include `<script>` tags for individual plugins. Example:
   </body>
 </html>
 ```
+
+Note that if you wish to include any of the [premium](https://fullcalendar.io/pricing) plugins in this manner, you will need to include the `@fullcalendar/premium-common` package too.


### PR DESCRIPTION
Per this issue: https://github.com/fullcalendar/fullcalendar/issues/7888

Make clear in the docs that the common package is required when using any of he premium packages.