### PR TITLE
Fix type description of 'listDayFormat' and 'listDaySideFormat'

### DIFF
--- a/_docs-v6/list-view/listDayFormat.md
+++ b/_docs-v6/list-view/listDayFormat.md
@@ -5,7 +5,24 @@ title: listDayFormat
 A [Date Formatter](date-formatting) that affects the text on the left side of the day headings in list view.
 
 <div class='spec' markdown='1'>
-String, `false`
+[Date Formatter](date-formatting), `false`, *defaults*:
+
+```js
+// like 'January 1, 2016', for 'list' view
+{ month: 'long', day: 'numeric', year: 'numeric' }
+
+// like 'Monday', for 'listDay' view
+{ weekday: 'long' }
+
+// like 'Monday', for 'listWeek' view
+{ weekday: 'long' }
+
+// no text, for 'listMonth' view
+false
+
+// no text, for 'listYear' view
+false
+```
 </div>
 
 <img src='listDayFormat.png' width='468' height='259' style='box-shadow: 0 1px 4px rgba(0,0,0,.3)' alt='customized list-view date strings' />

--- a/_docs-v6/list-view/listDaySideFormat.md
+++ b/_docs-v6/list-view/listDaySideFormat.md
@@ -5,7 +5,24 @@ title: listDaySideFormat
 A [Date Formatter](date-formatting) that affects the text on the right side of the day headings in list view.
 
 <div class='spec' markdown='1'>
-String, `false`
+[Date Formatter](date-formatting), `false`, *defaults*:
+
+```js
+// no text, for 'list' view
+false
+
+// no text, for 'listDay' view
+false
+
+// like 'January 1, 2016', for 'listWeek' view
+{ month: 'long', day: 'numeric', year: 'numeric' }
+
+// like 'Monday', for 'listMonth' view
+{ weekday: 'long' }
+
+// like 'Monday', for 'listYear' view
+{ weekday: 'long' }
+```
 </div>
 
 <img src='listDaySideFormat.png' width='468' height='259' style='box-shadow: 0 1px 4px rgba(0,0,0,.3)' alt='displaying alt date strings' />


### PR DESCRIPTION
I tripped over this when updating from v3 to v6.

Defaults taken from https://github.com/fullcalendar/fullcalendar/blob/d2498dd352ee4a45b17d34ad3cd947f944358ddb/packages/list/src/index.ts#L11-L36